### PR TITLE
Create simple inline expansion

### DIFF
--- a/slang/README.txt
+++ b/slang/README.txt
@@ -49,6 +49,7 @@ Options are:
   -stackmax set max stack size (default = 1000)
   -heapmax set max heap size (default = 1000)
   -t run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)
+  -ie use a simple inline expansion
   -help  Display this list of options
   --help  Display this list of options
 

--- a/slang/front_end.ml
+++ b/slang/front_end.ml
@@ -39,6 +39,18 @@ let translate e =
     in let _ = peek "After translation" e' Ast.string_of_expr 
     in e' 
 
+let inlineExpand e =
+    if Option.simple_inline_expansion then
+        let e1 = Inline_exp.lambdaExpand e
+        in let _ = peek "(Inline expansion) After expanding to lambdas" e1 Ast.string_of_expr 
+        in let e2 = Inline_exp.valueApply e1
+        in let _ = peek "(Inline expansion) After applying values" e2 Ast.string_of_expr 
+        in let e3 = Inline_exp.lambdaContract e2 
+        in let _ = peek "(Inline expansion) After contracting lambdas back together" e3 Ast.string_of_expr
+        in e3
+
+    else e
+
 (* the front end *)  
-let front_end file = translate (check (parse (init_lexbuf file)))
+let front_end file = inlineExpand (translate (check (parse (init_lexbuf file))))
     

--- a/slang/inline_exp.ml
+++ b/slang/inline_exp.ml
@@ -1,0 +1,200 @@
+(*
+Very simple inline expander
+Only dares to expand applications if operand is value, in order to avoid side effects,
+so it in practice mostly does constant propagation 
+
+Could support complex operands with a imperative style variable binding,
+However currently variable binding is done by creating a new function, 
+which defeats the purpose of function inling 
+
+Could also try to evaluate operations as well to get more complete constant folding
+
+Made in front-end due to easy access to whether functions are recursive or not
+probably would be better to implement it backend, 
+but that would require reanalysing functions for recursion
+
+Works in 3 phases:
+Expand non-recursive function calls to lambdas,
+Apply immutable operands to lambdas and inline then
+Contract remaining lambdas to function calls
+
+*)
+let rec propagate f = function 
+    | Ast.UnaryOp(op, e)   -> Ast.UnaryOp(op, f e)
+    | Ast.Op(e1, op, e2)   -> Ast.Op(f e1, op, f e2)
+    | Ast.If(e1, e2, e3)   -> Ast.If(f e1, f e2, f e3)
+    | Ast.Pair(e1, e2)     -> Ast.Pair(f e1, f e2)
+    | Ast.Fst e            -> Ast.Fst (f e)
+    | Ast.Snd e            -> Ast.Snd (f e)
+    | Ast.Inl e            -> Ast.Inl (f e)
+    | Ast.Inr e            -> Ast.Inl (f e)
+    | Ast.Lambda(x, e)     -> Ast.Lambda(x, f e)
+    | Ast.App(e1, e2)      -> Ast.App(f e1, f e2)
+    | Ast.Seq el           -> Ast.Seq (propagateList f el)
+    | Ast.While (e1, e2)   -> Ast.While (f e1, f e2)
+    | Ast.Ref e            -> Ast.Ref (f e)
+    | Ast.Deref e          -> Ast.Deref (f e)
+    | Ast.Assign (e1, e2)  -> Ast.Assign (f e1, f e2)
+    | Ast.LetFun(g, (x, e1), e2)      -> Ast.LetFun(g, (x, f e1), f e2)
+    | Ast.LetRecFun(g, (x, e1), e2)   -> Ast.LetRecFun(g, (x, f e1), f e2)
+    | Ast.Case(e, (x1, e1), (x2, e2)) -> Ast.Case(f e, (x1, f e1), (x2, f e2))
+    | other -> other
+
+and propagateList f = function 
+    | [] -> []
+    | e::el   -> (propagate f e)::(propagateList f el)
+
+
+let rec varToExpr x expr = function
+    (*Replace var(x) with expr*)
+    | Ast.Var(y) when (x=y)                           -> expr
+    (*variable got new value, dont continue*)
+    | Ast.Lambda(y, e)              when(y=x)         -> Ast.Lambda(y, e) 
+    | Ast.LetFun(f, (y, e1), e2)    when (f=x)||(y=x) -> Ast.LetFun(f, (y, e1), e2)
+    | Ast.LetRecFun(f, (y, e1), e2) when (f=x)||(y=x) -> Ast.LetRecFun(f, (y, e1), e2)
+
+    | other                                           -> propagate (varToExpr x expr) other
+  
+let rec exprToVar x expr = function
+    (* Replaces expr with var(x), and returns a tuple of the result and boolean 
+    whether any replacements were made *)
+    | e when (e=expr)                                 -> (Ast.Var(x), true)
+    (*variable got new value, dont continue*)
+    | Ast.Lambda(y, e)              when (y=x)        -> (Ast.Lambda(x, e), false) 
+    | Ast.LetFun(f, (y, e1), e2)    when (f=x)||(y=x) -> (Ast.LetFun(f, (y, e1), e2), true)
+    | Ast.LetRecFun(f, (y, e1), e2) when (f=x)||(y=x) -> (Ast.LetRecFun(f, (y, e1), e2), true)
+
+    (*propagation*)
+    | Ast.UnaryOp(op, e) -> 
+      let (e', r) = exprToVar x expr e in 
+      (Ast.UnaryOp(op, e'), r)
+
+    | Ast.Op(e1, op, e2) -> 
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.Op(e1', op, e2'), r1 || r2)
+
+    | Ast.If(e1, e2, e3) -> 
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      let (e3', r3) = exprToVar x expr e3 in
+      (Ast.If(e1', e2', e3'), (r1 || r2 || r3))
+
+    | Ast.Pair(e1, e2) ->       
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.Pair(e1', e2'), r1 || r2)
+
+    | Ast.Fst e -> 
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Fst e', r)
+
+    | Ast.Snd e -> 
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Snd e', r)
+
+    | Ast.Inl e ->  
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Inl e', r)
+
+    | Ast.Inr e ->  
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Inr e', r)
+
+    | Ast.Lambda(y, e) ->  
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Lambda(y, e'), r)
+
+    | Ast.App(e1, e2) ->        
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.App(e1', e2'), r1 || r2)
+
+    | Ast.Seq el -> 
+      let (el', r) = exprToVarList x expr el in 
+      (Ast.Seq el', r)
+
+    | Ast.While (e1, e2) -> 
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.While(e1', e2'), r1 || r2)
+
+    | Ast.Ref e -> 
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Ref e', r)
+
+    | Ast.Deref e -> 
+      let (e', r) = exprToVar x expr e in 
+      (Ast.Deref e', r)
+
+    | Ast.Assign (e1, e2) ->        
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.Assign(e1', e2'), r1 || r2)
+
+    | Ast.LetFun(f, (y, e1), e2) ->        
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.LetFun(f, (y, e1'), e2'), r1 || r2)
+
+    | Ast.LetRecFun(f, (y, e1), e2) -> 
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.LetRecFun(f, (y, e1'), e2'), r1 || r2)
+
+    | Ast.Case(e, (x1, e1), (x2, e2)) -> 
+      let (e1', r1) = exprToVar x expr e1 in
+      let (e2', r2) = exprToVar x expr e2 in
+      (Ast.Case(e, (x1, e1'), (x2, e2')), r1 || r2)
+
+    | other -> (other, false)
+
+and exprToVarList x expr = function
+    | [] -> ([], false)
+    | e::el -> 
+      let (e', r1) = exprToVar x expr e in
+      let (el', r2) = exprToVarList x expr el in
+      (e'::el', r1 || r2)
+
+
+let rec isImmutable = function
+    | Ast.Integer n   -> true
+    | Ast.Boolean b   -> true
+    | Ast.Unit        -> true
+    | Ast.Pair(e1, e2)-> (isImmutable e1) && (isImmutable e2)
+    | Ast.Inl e       -> isImmutable e
+    | Ast.Inr e       -> isImmutable e
+    | Ast.Lambda(x, e)-> true
+    | other           -> false
+
+let rec lambdaExpand = function
+  (* replace occurences of functions with their lambda *)
+  (* Keeps the LetFun statement to remember where functions was defined for contracting,
+     This Letfun gets in the way of some applications, for example function g in example/closure_add.slang.
+     Some other way of remembering where functions were defined would be more effective
+  *)
+    | Ast.LetFun(f, (x, e1), e2) -> 
+        let e1' = lambdaExpand e1 in
+        let e2' = lambdaExpand (varToExpr f (Lambda(x, e1')) e2) in
+        Ast.LetFun(f, (x, e1'), e2')
+    | other -> propagate lambdaExpand other
+
+let rec valueApply = function
+    (* Inline lambda applications, if operand is immutable *)
+    | Ast.App(e1, e2) ->
+        let e1' = valueApply e1 in
+        let e2' = valueApply e2 in
+        (match e1' with
+            | Ast.Lambda(x, e3) when (isImmutable e2') -> valueApply (varToExpr x e2' e3)
+            | nonApplicable -> Ast.App(e1', e2')
+        )
+    | other -> propagate valueApply other
+
+let rec lambdaContract = function
+    | Ast.LetFun(f, (x, e1), e2) ->
+        let (e2', r) = exprToVar f (Lambda(x, e1)) e2 in
+        if r then
+          Ast.LetFun(f, (x, lambdaContract e1), lambdaContract e2')
+        else (* No references to f left, we can remove function block*)
+          lambdaContract e2'
+    | other -> propagate lambdaContract other

--- a/slang/inline_exp.mli
+++ b/slang/inline_exp.mli
@@ -1,0 +1,6 @@
+
+val lambdaExpand : Ast.expr -> Ast.expr
+
+val valueApply : Ast.expr -> Ast.expr
+
+val lambdaContract : Ast.expr -> Ast.expr

--- a/slang/option.ml
+++ b/slang/option.ml
@@ -22,6 +22,7 @@ let show_compiled  = ref false
 let set_infile f   = infile := f
 let stack_max      = ref 1000
 let heap_max       = ref 1000
+let simple_inline_expansion = ref false
 
 let option_spec = [
      ("-V",    Arg.Set verbose_front, "verbose front end");
@@ -37,7 +38,8 @@ let option_spec = [
      ("-all",  Arg.Unit use_all,      "all interpreters");
      ("-stackmax",  Arg.Set_int stack_max, "set max stack size (default = 1000)");
      ("-heapmax",  Arg.Set_int heap_max, "set max heap size (default = 1000)");
-     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)")
+     ("-t",    Arg.Set run_tests,     "run all test/*.slang with each selected interpreter, report unexpected outputs (silent otherwise)");
+     ("-ie", Arg.Set simple_inline_expansion, "use a simple inline expansion")
     ]
 let usage_msg = "Usage: slang.byte [options] [<file>]\nOptions are:"
 
@@ -60,3 +62,4 @@ let use_i4x86     = !use_i4x86
 let show_compiled = !show_compiled
 let stack_max     = !stack_max
 let heap_max      = !heap_max
+let simple_inline_expansion = !simple_inline_expansion

--- a/slang/option.mli
+++ b/slang/option.mli
@@ -14,3 +14,4 @@ val use_i4x86: bool
 val show_compiled: bool
 val stack_max: int
 val heap_max: int
+val simple_inline_expansion: bool


### PR DESCRIPTION
Very simple inline expander
Only dares to expand function calls if operand is value, in order to avoid side effects,
so it in practice mostly does constant propagation 

Could support complex operands with a imperative style variable binding,
However currently variable binding is done by creating a new function, 
which defeats the purpose of function inlining 

Could also try to evaluate operations as well to get more complete constant folding

Made in front-end due to easy access to whether functions are recursive or not
probably would be better to implement it backend, 
but that would require reanalysing functions for recursion

Works in 3 phases:
Expand non-recursive function calls to lambdas,
Apply immutable operands to lambdas and inline them
Contract remaining lambdas to function calls
